### PR TITLE
Remove directory switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If your organization uses Superblocks EU, set the `domain` to `eu.superblocks.co
       ...
 
       - name: Pull
-        uses: superblocksteam/export-action@v1
+        uses: superblocksteam/export-action
         id: pull
         with:
           token: ${{ secrets.SUPERBLOCKS_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -29,4 +29,3 @@ runs:
   env:
     SUPERBLOCKS_AUTHOR_NAME: 'superblocks-app[bot]'
     SUPERBLOCKS_AUTHOR_EMAIL: 'superblocks-app[bot]@users.noreply.github.com'
-    REPO_DIR: ${{ github.workspace }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,9 +11,6 @@ CLI_VERSION="$5"
 
 SUPERBLOCKS_BOT_NAME="superblocks-app[bot]"
 
-cd "$REPO_DIR"
-git config --global --add safe.directory "$REPO_DIR"
-
 # Get the name of the actor who made the last commit
 actor_name=$(git show -s --format='%an' "$SHA")
 if [ "$actor_name" != "$SUPERBLOCKS_BOT_NAME" ]; then


### PR DESCRIPTION
This PR removes any repo switching in the entrypoint as it is only needed for multi-repo checkouts (testing with private actions).