### PR TITLE
Add workflows to publish images and manage major tag on tag pushes

### DIFF
--- a/.github/workflows/move-major-tag.yaml
+++ b/.github/workflows/move-major-tag.yaml
@@ -1,0 +1,23 @@
+name: Update Major Release Tag
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  movetag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get major version num and update tag
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          MAJOR="${VERSION%%.*}"
+
+          # https://github.com/actions/checkout/pull/1184
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -fa "${MAJOR}" -m "Floating tag for major version ${MAJOR}"
+          git push origin "${MAJOR}" --force

--- a/.github/workflows/move-major-tag.yaml
+++ b/.github/workflows/move-major-tag.yaml
@@ -8,7 +8,7 @@ jobs:
   movetag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get major version num and update tag
         run: |

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,0 +1,68 @@
+name: Publish docker images
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
+
+env:
+  DOCKERHUB_IMAGE_NAME: superblocksteam/export-action
+  GHCR_IMAGE_NAME: ghcr.io/superblocksteam/export-action
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.DOCKERHUB_IMAGE_NAME }}
+            ${{ env.GHCR_IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -31,11 +31,12 @@ jobs:
             ${{ env.GHCR_IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
+            # branch event
             type=ref,event=branch
+            # tag event
+            type=ref,event=tag
+            # pull request event
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=sha
 
       - name: Set up QEMU
@@ -45,14 +46,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -63,6 +64,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:18-bookworm-slim
 
-COPY entrypoint.sh /entrypoint.sh
+ARG SUPERBLOCKS_CLI_VERSION='^1.1.0'
 
 # Install Superblocks CLI dependencies
 RUN apt-get update && apt-get install -y \
   git \
   jq \
   && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}"
+
+COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,6 @@ inputs:
   path:
     description: 'The relative path to the Superblocks config file'
     default: '.superblocks/superblocks.json'
-  cli_version:
-    description: 'The Superblocks CLI version'
-    default: '^1.1.0'
 
 runs:
   using: 'docker'
@@ -25,7 +22,6 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.domain }}
     - ${{ inputs.path }}
-    - ${{ inputs.cli_version }}
   env:
     SUPERBLOCKS_AUTHOR_NAME: 'superblocks-app[bot]'
     SUPERBLOCKS_AUTHOR_EMAIL: 'superblocks-app[bot]@users.noreply.github.com'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,6 @@ SHA="$1"
 TOKEN="$2"
 DOMAIN="$3"
 CONFIG_PATH="$4"
-CLI_VERSION="$5"
 
 SUPERBLOCKS_BOT_NAME="superblocks-app[bot]"
 
@@ -26,9 +25,6 @@ fi
 changed_files=$(git diff "${SHA}"^ --name-only)
 
 if [ -n "$changed_files" ]; then
-    # Install Superblocks CLI
-    printf "\nInstalling Superblocks CLI (%s)...\n" "$CLI_VERSION"
-    npm install -g @superblocksteam/cli@"$CLI_VERSION"
     superblocks --version
 
     # Login to Superblocks


### PR DESCRIPTION
This PR introduces 2 workflows:
- build and push images to Dockerhub and GHCR on tag pushes, and only build images on branch and pr events
- move major tag on release creation to allow for the expected behavior when referencing action using `vX` scheme

This PR also removes the cli_version input in favor of managing that through the built image itself.

In the future, we could choose to push images (to possibly on GHCR) on certain branch events too.