### PR TITLE
Publish images with the major and major.minor tags

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -33,11 +33,17 @@ jobs:
           tags: |
             # branch event
             type=ref,event=branch
-            # tag event
-            type=ref,event=tag
             # pull request event
             type=ref,event=pr
-            type=sha
+            # tag event, e.g. v1.2.3
+            type=ref,event=tag
+            # the following are only available for push tag events with valid
+            # semver tags
+            # https://github.com/docker/metadata-action#typesemver
+            # major version, e.g. v1.2.3 -> v1
+            type=semver,pattern=v{{major}}
+            # minor version, e.g. v1.2.3 -> v1.2
+            type=semver,pattern=v{{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
This PR includes 2 changes
- publishing tags in the form of `v{{major}}` and `v{{major.minor}}` alongside the fully qualified semver
- removal of the SHA based tag publish