### PR TITLE
Install CLI at runtime, not build-time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM node:18-bookworm-slim
 
-ARG SUPERBLOCKS_CLI_VERSION='^1.3.0'
-
 # Install Superblocks CLI dependencies
 RUN apt-get update && apt-get install -y \
   git \
   jq \
   && rm -rf /var/lib/apt/lists/*
-
-RUN npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}"
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+readonly SUPERBLOCKS_CLI_VERSION='^1.4.0'
+
 COMMIT_SHA="${COMMIT_SHA:-HEAD}"
 SUPERBLOCKS_DOMAIN="${SUPERBLOCKS_DOMAIN:-app.superblocks.com}"
 SUPERBLOCKS_CONFIG_PATH="${SUPERBLOCKS_CONFIG_PATH:-.superblocks/superblocks.json}"
@@ -50,6 +52,9 @@ fi
 changed_files=$(git diff "${COMMIT_SHA}"^ --name-only)
 
 if [ -n "$changed_files" ]; then
+    # Install Superblocks CLI
+    npm install -g @superblocksteam/cli@"${SUPERBLOCKS_CLI_VERSION}"
+
     superblocks --version
 
     # Login to Superblocks


### PR DESCRIPTION
This ensures that the latest version of the CLI is being used